### PR TITLE
feat: drop Django < 4.2 support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -709,7 +709,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1236,4 +1235,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "20fa92cdc4fc0ab646e1892f8abe13169324a135ff76b273c62c0324cb566348"
+content-hash = "f0f1b573f98a417593200a55b77b315126f8d32d67917e595035e35fcbca1b97"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Topic :: Software Development :: Libraries",
@@ -30,7 +27,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = ">=3.2"
+django = ">=4.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ requires =
     tox>=4.2
 env_list =
     py312-django{50,42}
-    py311-django{50,42,41}
-    py310-django{50,42,41,40,32}
-    py39-django{42,41,40,32}
-    py38-django{42,41,40,32}
+    py311-django{50,42}
+    py310-django{50,42}
+    py39-django{42}
+    py38-django{42}
 
 [testenv]
 set_env =
@@ -19,9 +19,6 @@ deps =
     # All supported Django versions
     django50: Django>=5.0,<5.1
     django42: Django>=4.2,<5.0
-    django41: Django>=4.1,<4.2
-    django40: Django>=4.0,<4.1
-    django32: Django>=3.2,<4.0
 commands =
     python \
       -m pytest {posargs:tests}


### PR DESCRIPTION
BREAKING CHANGE: drop support for Django < 4.2

Committed via https://github.com/asottile/all-repos