### PR TITLE
ci: fix coverage reporting with parallel runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
         shell: bash
       - run: tox -f py$(echo ${{ matrix.python-version }} | tr -d .)
         shell: bash
+      - run: |
+          uv run coverage combine
+          uv run coverage xml
+        shell: bash
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ urls.repository = "https://github.com/browniebroke/django-admin-helpers"
 
 [dependency-groups]
 dev = [
+  "coverage",
   "pytest>=8,<9",
-  "pytest-cov>=6,<7",
   "pytest-django>=4.5,<5",
 ]
 docs = [
@@ -92,15 +92,22 @@ lint.isort.known-first-party = [ "django_admin_helpers", "tests" ]
 addopts = """\
     -v
     -Wdefault
-    --cov=django_admin_helpers
-    --cov-report=term
-    --cov-report=xml
     --ds=tests.settings
     """
 pythonpath = [ "src" ]
 
 [tool.coverage.run]
 branch = true
+parallel = true
+source = [
+  "django_admin_helpers",
+]
+
+[tool.coverage.paths]
+source = [
+  "src",
+  ".tox/**/site-packages",
+]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,5 @@ deps =
     django42: Django>=4.2,<5.0
 commands =
     python \
+      -m coverage run \
       -m pytest {posargs:tests}

--- a/uv.lock
+++ b/uv.lock
@@ -242,11 +242,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1a/0b9c32220ad694d66062f571cc5cedfa9997b64a591e8a500bb63de1bd40/coverage-7.8.2-py3-none-any.whl", hash = "sha256:726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32", size = 203623, upload-time = "2025-05-23T11:39:53.846Z" },
 ]
 
-[package.optional-dependencies]
-toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
-]
-
 [[package]]
 name = "django"
 version = "4.2.21"
@@ -293,8 +288,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "coverage" },
     { name = "pytest" },
-    { name = "pytest-cov" },
     { name = "pytest-django" },
 ]
 docs = [
@@ -309,8 +304,8 @@ requires-dist = [{ name = "django", specifier = ">=4.2" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "coverage" },
     { name = "pytest", specifier = ">=8,<9" },
-    { name = "pytest-cov", specifier = ">=6,<7" },
     { name = "pytest-django", specifier = ">=4.5,<5" },
 ]
 docs = [
@@ -564,19 +559,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
-]
-
-[[package]]
-name = "pytest-cov"
-version = "6.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage", extra = ["toml"] },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857, upload-time = "2025-04-05T14:07:51.592Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841, upload-time = "2025-04-05T14:07:49.641Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description of change

The coverage report is wrong in Codecov, because we don't have `parallel = true`, and we run multiple versions on the same CI worker, so only the latest version of Django that runs is reported.

The project uses `pytest-cov` which does not work with this option:

> This plugin overrides the parallel option of coverage. Unless you also run coverage without pytest-cov it’s pointless to set those options in your .coveragerc.

Dropping this dependency in an attempt to get more accurate combined coverage.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/django-admin-helpers/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.
