### PR TITLE
chore(deps): downgrade tiangolo/issue-manager action to v0.7.1

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -18,7 +18,7 @@ jobs:
   issue-manager:
     runs-on: ubuntu-24.04
     steps:
-      - uses: tiangolo/issue-manager@48bacd85fb842cc27efee25e834edb00aad8f263 # 0.8.0
+      - uses: tiangolo/issue-manager@75d60679db1ea348f6f6ea1d0e20de80a7c04645 # 0.7.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >


### PR DESCRIPTION
Reverts browniebroke/django-admin-helpers#544