### PR TITLE
feat: add admin mixin to delete files as instances are deleted

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3,6 +3,16 @@
 Reference
 =========
 
+Links
+-----
+
 .. automodule:: django_admin_helpers.links
+   :members:
+   :noindex:
+
+Mixins
+------
+
+.. automodule:: django_admin_helpers.mixins
    :members:
    :noindex:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,4 +86,31 @@ class PostAdmin(admin.ModelAdmin):
 
 You need to add the method, and it's pretty explicit what's happening and where the URL comes from.
 
+## Deleting files along with model instances
+
+When a model has a `FileField` or `ImageField`, Django doesn't remove the underlying files from storage when instances are deleted: the records disappear from the database, but the files stay behind. The `FilesDeleteMixin` hooks into the admin deletion flow to delete the files from storage as well.
+
+Let's say the `Author` model has a picture:
+
+```python
+class Author(models.Model):
+    full_name = models.CharField(max_length=50)
+    picture = models.ImageField(upload_to="authors")
+```
+
+Add the mixin to the model admin and list the file fields to clean up in `file_field_names`:
+
+```python
+from django_admin_helpers.mixins import FilesDeleteMixin
+
+
+@admin.register(Author)
+class AuthorAdmin(FilesDeleteMixin, admin.ModelAdmin):
+    file_field_names = ["picture"]
+```
+
+Now deleting an author, either from their admin change page or via the bulk delete action in the change list, also deletes their picture from storage. If a file can't be deleted for any reason, the error is logged and the record is deleted from the database anyway.
+
+Note that this only applies to deletions performed through the admin: deleting instances from other code paths (views, shell, ...) still leaves the files in storage.
+
 Ready to dive in? Check out the {ref}`next section <reference>` about the full API or {ref}`the configuration options <configuration>` available.

--- a/src/django_admin_helpers/mixins.py
+++ b/src/django_admin_helpers/mixins.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+from typing import ClassVar
+
+from django.db.models import Model, QuerySet
+from django.http import HttpRequest
+
+logger = logging.getLogger(__name__)
+
+
+class FilesDeleteMixin:
+    """
+    Mixin for ``ModelAdmin`` classes to delete files along with model instances.
+
+    By default, Django leaves the files of ``FileField`` (and ``ImageField``)
+    in storage when the model instances referencing them are deleted. This
+    mixin hooks into the admin deletion flow to also delete the files from
+    storage, both when deleting a single instance from its change page and
+    when using the bulk delete action from the change list.
+
+    Set the ``file_field_names`` attribute to the list of file field names
+    to delete (defaults to ``["file"]``)::
+
+        class DocumentAdmin(FilesDeleteMixin, admin.ModelAdmin):
+            file_field_names = ["file", "thumbnail"]
+
+    If a file cannot be deleted, the error is logged and the instance is
+    deleted from the database anyway.
+    """
+
+    file_field_names: ClassVar[list[str]] = ["file"]
+
+    def delete_model(self, request: HttpRequest, obj: Model) -> None:
+        """Delete the file(s) associated with the instance."""
+        self._delete_files_from_obj(obj)
+        super().delete_model(request, obj)  # type: ignore[misc]
+
+    def delete_queryset(self, request: HttpRequest, queryset: QuerySet[Model]) -> None:
+        """Delete the file(s) associated with the instances in the queryset."""
+        for obj in queryset:
+            self._delete_files_from_obj(obj)
+        super().delete_queryset(request, queryset)  # type: ignore[misc]
+
+    def _delete_files_from_obj(self, obj: Model) -> None:
+        """Delete the file(s) associated with the model instance."""
+        for field_name in self.file_field_names:
+            try:
+                getattr(obj, field_name).delete(save=False)
+            except Exception as exc:
+                logger.exception(
+                    "Could not delete file on field '%s' from %s (%r) "
+                    "- proceeding with deleting record from DB",
+                    field_name,
+                    obj,
+                    exc,
+                )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,6 +10,12 @@ DATABASES = {
     },
 }
 
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.InMemoryStorage",
+    },
+}
+
 USE_TZ = True
 TIME_ZONE = "UTC"
 ROOT_URLCONF = "tests.urls"

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,0 +1,108 @@
+import logging
+from typing import ClassVar
+
+import pytest
+from django.contrib import admin
+from django.core.files.base import ContentFile
+
+from django_admin_helpers.mixins import FilesDeleteMixin
+
+from .testapp.models import Author, Blog
+
+
+class AuthorAdmin(FilesDeleteMixin, admin.ModelAdmin):
+    file_field_names: ClassVar[list[str]] = ["picture", "attachment"]
+
+
+class BlogAdmin(FilesDeleteMixin, admin.ModelAdmin):
+    pass
+
+
+@pytest.fixture
+def author_admin():
+    return AuthorAdmin(Author, admin.AdminSite())
+
+
+def make_author(suffix="", with_attachment=False):
+    author = Author(full_name=f"Author {suffix}")
+    author.picture.save(f"picture{suffix}.png", ContentFile(b"fake image"), save=False)
+    if with_attachment:
+        author.attachment.save(
+            f"attachment{suffix}.txt", ContentFile(b"fake file"), save=False
+        )
+    author.save()
+    return author
+
+
+@pytest.mark.django_db
+def test_delete_model_deletes_file(rf, author_admin):
+    author = make_author()
+    storage = author.picture.storage
+    picture_name = author.picture.name
+    assert storage.exists(picture_name)
+
+    author_admin.delete_model(rf.post("/"), author)
+
+    assert not storage.exists(picture_name)
+    assert not Author.objects.exists()
+
+
+@pytest.mark.django_db
+def test_delete_model_deletes_all_listed_files(rf, author_admin):
+    author = make_author(with_attachment=True)
+    storage = author.picture.storage
+    file_names = [author.picture.name, author.attachment.name]
+
+    author_admin.delete_model(rf.post("/"), author)
+
+    assert not any(storage.exists(name) for name in file_names)
+    assert not Author.objects.exists()
+
+
+@pytest.mark.django_db
+def test_delete_queryset_deletes_files(rf, author_admin):
+    authors = [make_author(suffix=str(i)) for i in range(3)]
+    storage = authors[0].picture.storage
+    picture_names = [author.picture.name for author in authors]
+
+    author_admin.delete_queryset(rf.post("/"), Author.objects.all())
+
+    assert not any(storage.exists(name) for name in picture_names)
+    assert not Author.objects.exists()
+
+
+@pytest.mark.django_db
+def test_delete_model_without_file_still_deletes_record(rf, author_admin, caplog):
+    author = make_author()  # no attachment
+
+    with caplog.at_level(logging.ERROR):
+        author_admin.delete_model(rf.post("/"), author)
+
+    assert not Author.objects.exists()
+    assert caplog.text == ""
+
+
+@pytest.mark.django_db
+def test_delete_error_is_logged_and_record_deleted(rf, caplog):
+    blog = Blog.objects.create(name="Blog", description="A blog")
+    blog_admin = BlogAdmin(Blog, admin.AdminSite())
+
+    # default file_field_names is ["file"], which doesn't exist on Blog
+    with caplog.at_level(logging.ERROR):
+        blog_admin.delete_model(rf.post("/"), blog)
+
+    assert not Blog.objects.exists()
+    assert "Could not delete file on field 'file'" in caplog.text
+
+
+@pytest.mark.django_db
+def test_delete_queryset_error_is_logged_and_records_deleted(rf, caplog):
+    for i in range(2):
+        Blog.objects.create(name=f"Blog {i}", description="A blog")
+    blog_admin = BlogAdmin(Blog, admin.AdminSite())
+
+    with caplog.at_level(logging.ERROR):
+        blog_admin.delete_queryset(rf.post("/"), Blog.objects.all())
+
+    assert not Blog.objects.exists()
+    assert caplog.text.count("Could not delete file on field 'file'") == 2

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -12,6 +12,7 @@ class Blog(models.Model):
 class Author(models.Model):
     full_name = models.CharField(max_length=50)
     picture = models.ImageField(upload_to="authors")
+    attachment = models.FileField(upload_to="attachments", blank=True)
 
     def __str__(self):  # noqa: D105
         return self.full_name


### PR DESCRIPTION
### Description of change

Admin mixin to delete file fields when model instances are deleted.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/django-admin-helpers/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If the lint job is failing, try `prek run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
